### PR TITLE
160 Clé secrète de seats.io publique

### DIFF
--- a/api/app/Http/Controllers/LanController.php
+++ b/api/app/Http/Controllers/LanController.php
@@ -174,7 +174,8 @@ class LanController extends Controller
 
         return response()->json($this->lanService->get(
             $request->input('lan_id'),
-            $request->input('fields')
+            $request->input('fields'),
+            Auth::id()
         ), 200);
     }
 

--- a/api/app/Services/Implementation/LanServiceImpl.php
+++ b/api/app/Services/Implementation/LanServiceImpl.php
@@ -105,7 +105,7 @@ class LanServiceImpl implements LanService
         return GetAllResource::collection($this->lanRepository->getAll());
     }
 
-    public function get(int $lanId, ?string $fields): GetResource
+    public function get(int $lanId, ?string $fields, ?int $userId): GetResource
     {
         // Obtenir le nombre de places occupées
         $placeCount = $this->seatRepository->getReservedPlaces($lanId);
@@ -116,8 +116,20 @@ class LanServiceImpl implements LanService
         // Trouver le LAN
         $lan = $this->lanRepository->findById($lanId);
 
+        // Déterminer si l'utilisateur peut voir la clé secrète de seats.io
+        $canSeeSeatsioSecretKey = null;
+        if (is_null($userId)) {
+            $canSeeSeatsioSecretKey = false;
+        } else {
+            $canSeeSeatsioSecretKey = $this->roleRepository->userHasPermission(
+                'edit-lan',
+                $userId,
+                $lanId
+            );
+        }
+
         // Retourner les détails du LAN selon les champs spécifiés
-        return new GetResource($lan, $placeCount, $images, $fields);
+        return new GetResource($lan, $placeCount, $images, $fields, $canSeeSeatsioSecretKey);
     }
 
     public function setCurrent(int $lanId): Lan

--- a/api/app/Services/LanService.php
+++ b/api/app/Services/LanService.php
@@ -80,9 +80,10 @@ interface LanService
      *
      * @param int $lanId Id du LAN
      * @param string|null $fields Champs à afficher
+     * @param int $userId Id de l'utilisateur courant
      * @return GetResource Détails du LAN
      */
-    public function get(int $lanId, ?string $fields): GetResource;
+    public function get(int $lanId, ?string $fields, ?int $userId): GetResource;
 
     /**
      * Mettre un LAN comme courant.

--- a/api/documentation/source/includes/_lan.md
+++ b/api/documentation/source/includes/_lan.md
@@ -136,6 +136,10 @@ rules | Règlements.
 description | Description.
 images | Images de présentation.
 
+<aside class="notice">
+Pour accéder au champ <code>secret_key</code>, il est nécessaire que l'utilisateur possède la permission <code>edit-lan</code>
+</aside>
+
 ### Format de réponse
 
 > Exemple de réponse

--- a/api/tests/Unit/Controller/Lan/GetTest.php
+++ b/api/tests/Unit/Controller/Lan/GetTest.php
@@ -35,7 +35,6 @@ class GetTest extends TestCase
                     'reserved' => 0,
                     'total' => $this->lan->places
                 ],
-                'secret_key' => $this->lan->secret_key,
                 'event_key' => $this->lan->event_key,
                 'public_key' => $this->lan->public_key,
                 'price' => $this->lan->price,
@@ -61,7 +60,6 @@ class GetTest extends TestCase
                 'tournament_reservation_start' => $lan->tournament_reservation_start,
                 'longitude' => $lan->longitude,
                 'latitude' => $lan->latitude,
-                'secret_key' => $lan->secret_key,
                 'event_key' => $lan->event_key,
                 'public_key' => $lan->public_key,
                 'places' => [
@@ -87,6 +85,78 @@ class GetTest extends TestCase
                 'lan_start' => $this->lan->lan_start,
                 'lan_end' => $this->lan->lan_end,
                 'seat_reservation_start' => $this->lan->seat_reservation_start
+            ])
+            ->assertResponseStatus(200);
+    }
+
+    public function testGetParametersSecretKeyUnauthorized(): void
+    {
+        $this->json('GET', 'http://' . env('API_DOMAIN') . '/lan', [
+            'fields' => 'secret_key',
+            'lan_id' => $this->lan->id
+        ])
+            ->seeJsonEquals([
+                'success' => false,
+                'status' => 403,
+                'message' => 'REEEEEEEEEE'
+            ])
+            ->assertResponseStatus(403);
+    }
+
+    public function testGetParametersSecretKeyAuthorized(): void
+    {
+        $user = factory('App\Model\User')->create();
+        $this->addLanPermissionToUser(
+            $user->id,
+            $this->lan->id,
+            'edit-lan'
+        );
+
+        $this->actingAs($user)
+            ->json('GET', 'http://' . env('API_DOMAIN') . '/lan', [
+                'fields' => 'secret_key',
+                'lan_id' => $this->lan->id
+            ])
+            ->seeJsonEquals([
+                'id' => $this->lan->id,
+                'secret_key' => $this->lan->secret_key
+            ])
+            ->assertResponseStatus(200);
+    }
+
+    public function testGetSecretKeyAuthorized(): void
+    {
+        $user = factory('App\Model\User')->create();
+        $this->addLanPermissionToUser(
+            $user->id,
+            $this->lan->id,
+            'edit-lan'
+        );
+
+        $this->actingAs($user)
+            ->json('GET', 'http://' . env('API_DOMAIN') . '/lan', [
+                'lan_id' => $this->lan->id
+            ])
+            ->seeJsonEquals([
+                'id' => $this->lan->id,
+                'name' => $this->lan->name,
+                'lan_start' => $this->lan->lan_start,
+                'lan_end' => $this->lan->lan_end,
+                'seat_reservation_start' => $this->lan->seat_reservation_start,
+                'tournament_reservation_start' => $this->lan->tournament_reservation_start,
+                'longitude' => $this->lan->longitude,
+                'latitude' => $this->lan->latitude,
+                'event_key' => $this->lan->event_key,
+                'public_key' => $this->lan->public_key,
+                'secret_key' => $this->lan->secret_key,
+                'places' => [
+                    'reserved' => 0,
+                    'total' => $this->lan->places
+                ],
+                'price' => $this->lan->price,
+                'rules' => $this->lan->rules,
+                'description' => $this->lan->description,
+                'images' => []
             ])
             ->assertResponseStatus(200);
     }

--- a/api/tests/Unit/Service/Lan/GetTest.php
+++ b/api/tests/Unit/Service/Lan/GetTest.php
@@ -22,7 +22,7 @@ class GetTest extends TestCase
 
     public function testGetSimple(): void
     {
-        $result = $this->lanService->get($this->lan->id, null);
+        $result = $this->lanService->get($this->lan->id, null, null);
 
         $this->assertEquals($this->lan->id, $result['id']);
         $this->assertEquals($this->lan->name, $result['name']);
@@ -44,7 +44,8 @@ class GetTest extends TestCase
     {
         $result = $this->lanService->get(
             $this->lan->id,
-            'lan_start,lan_start,lan_end,seat_reservation_start'
+            'lan_start,lan_start,lan_end,seat_reservation_start',
+            null
         );
 
         $this->assertEquals($this->lan->id, $result['id']);


### PR DESCRIPTION
Un utilisateur doit avoir la permission "edit-lan" pour accéder au champ "secret_key". 

Si aucun champ du LAN n'est demandé, le champs ne sera pas retourné à moins que l'utilisateur ait la permission. 

S'il demande à voir le champs dans la liste de champ, et qu'il ne possède pas le champ, une erreur d'authorisation est lancée.